### PR TITLE
support configurable include paths for Sass imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Support `LIBSASSCOMPILER_INCLUDE_PATHS` setting to pass extra import search paths to `sass.compile(..., include_paths=...)`.
+
+### Fixed
+- SCSS imports can now resolve shared files outside the source file directory when custom include paths are configured.
+
 ## [0.2.0] - 2024-08-24
 ### Fixed
 - Fix dependencies for working with django 2 (pending to update package so it works with django 3 and 4)

--- a/README.md
+++ b/README.md
@@ -24,6 +24,30 @@ PIPELINE['COMPILERS'] = (
 )
 ```
 
+Optional: add extra include paths for `@import` resolution.
+
+```python
+LIBSASSCOMPILER_INCLUDE_PATHS = [
+    '/path/to/shared/styles',
+    '/path/to/another/scss/dir',
+]
+```
+
+These paths are passed to `sass.compile(..., include_paths=...)`.
+
+Imports are resolved from:
+
+1. the directory of the source scss/sass file
+2. `LIBSASSCOMPILER_INCLUDE_PATHS` (if defined)
+
+Example:
+
+```scss
+@import "shared";
+```
+
+With `LIBSASSCOMPILER_INCLUDE_PATHS = ['/path/to/shared/styles']`, libsass will resolve `/path/to/shared/styles/shared.scss`.
+
 # Contribute
 
 1. Fork

--- a/libsasscompiler/__init__.py
+++ b/libsasscompiler/__init__.py
@@ -6,6 +6,7 @@ ruby sass anymore.
 
 import sass
 import codecs
+import os
 from pipeline.compilers import CompilerBase
 from django.conf import settings
 
@@ -23,9 +24,18 @@ class LibSassCompiler(CompilerBase):
         """Process sass file."""
         myfile = codecs.open(outfile, 'w', 'utf-8')
 
+        include_paths = [os.path.dirname(infile)]
+        include_paths.extend(getattr(settings,
+                                     'LIBSASSCOMPILER_INCLUDE_PATHS',
+                                     []))
+        compile_kwargs = {
+            'filename': infile,
+            'include_paths': include_paths,
+        }
+
         if settings.DEBUG:
-            myfile.write(sass.compile(filename=infile))
+            myfile.write(sass.compile(**compile_kwargs))
         else:
-            myfile.write(sass.compile(filename=infile,
-                                      output_style='compressed'))
+            compile_kwargs['output_style'] = 'compressed'
+            myfile.write(sass.compile(**compile_kwargs))
         return myfile.close()

--- a/test_djangoapp/django_app/static/shared.scss
+++ b/test_djangoapp/django_app/static/shared.scss
@@ -1,0 +1,1 @@
+$shared-color: red;

--- a/test_djangoapp/test_styles/tests/import_main.scss
+++ b/test_djangoapp/test_styles/tests/import_main.scss
@@ -1,0 +1,5 @@
+@import "shared";
+
+.example {
+  color: $shared-color;
+}


### PR DESCRIPTION
closes https://github.com/sonic182/libsasscompiler/issues/6

Allow users to set LIBSASSCOMPILER_INCLUDE_PATHS so imports can resolve shared SCSS files across apps. Add regression coverage and document the import search path behavior.
